### PR TITLE
What i was talking about. The constructor map field originally was wr…

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -132,7 +132,7 @@ namespace AutoMapper.Execution
                     continue;
                 }
                 var property = TryPropertyMap(propertyMap);
-                if(_typeMap.CanResolveCtor && _typeMap.ConstructorParameterMatches(propertyMap.DestinationProperty.Name))
+                if(_typeMap.ConstructorMap?.CanResolve == true && _typeMap.ConstructorParameterMatches(propertyMap.DestinationProperty.Name))
                 {
                     property = IfThen(NotEqual(_initialDestination, Constant(null)), property);
                 }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -45,7 +45,6 @@ namespace AutoMapper
         public TypePair Types { get; }
 
         public ConstructorMap ConstructorMap { get; set; }
-        public bool CanResolveCtor => ConstructorMap?.CanResolve == true;
 
         public TypeDetails SourceTypeDetails { get; }
         public TypeDetails DestinationTypeDetails { get; }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -45,6 +45,7 @@ namespace AutoMapper
         public TypePair Types { get; }
 
         public ConstructorMap ConstructorMap { get; set; }
+        public bool CanResolveCtor => ConstructorMap?.CanResolve == true;
 
         public TypeDetails SourceTypeDetails { get; }
         public TypeDetails DestinationTypeDetails { get; }


### PR DESCRIPTION
…itten in one place and read in one place. The same with the out param - written in one place and read in another. I just moved the logic to the one spot used.